### PR TITLE
Fixed decryption error due to incorrect size shared secret

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -199,7 +199,9 @@ func computeSecret(curve elliptic.Curve, private privateKey, public publicKey) [
 	x1, y1 := elliptic.Unmarshal(curve, public)
 
 	x2, _ := curve.ScalarMult(x1, y1, private)
-	return x2.Bytes()
+	result := x2.Bytes()
+	result = append(bytes.Repeat([]byte{0}, secretLen-len(result)), result...)
+	return result
 }
 
 func randomKey(curve elliptic.Curve) (privateKey, publicKey, error) {

--- a/keys.go
+++ b/keys.go
@@ -199,9 +199,8 @@ func computeSecret(curve elliptic.Curve, private privateKey, public publicKey) [
 	x1, y1 := elliptic.Unmarshal(curve, public)
 
 	x2, _ := curve.ScalarMult(x1, y1, private)
-	result := x2.Bytes()
-	result = append(bytes.Repeat([]byte{0}, secretLen-len(result)), result...)
-	return result
+	r := make([]byte, secretLen)
+	return x2.FillBytes(r)
 }
 
 func randomKey(curve elliptic.Curve) (privateKey, publicKey, error) {


### PR DESCRIPTION
When calling `Curve.ScalarMult`, we get `big.Int` as a result. Sometimes the number is smaller than expected and then calling `x2.Bytes()` returns a 31 bytes slice, which leads to decryption failure.

This fixes the problems and adds padding at the beggining of the slice to make sure the slice is always 32 bytes long.