### PR TITLE
fix: 小さな修正

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -8,6 +8,7 @@
 package httpece
 
 import (
+	"crypto/aes"
 	"crypto/ecdh"
 	"crypto/sha256"
 	"math"
@@ -18,7 +19,7 @@ const (
 	recordSizeMin     = 3
 	recordSizeMax     = math.MaxInt32
 	keyIDLenMax       = math.MaxUint8
-	keyLen            = 16
+	keyLen            = aes.BlockSize
 	recodeSizeLen     = 4
 	nonceLen          = 12
 	secretLen         = sha256.Size

--- a/decrypt.go
+++ b/decrypt.go
@@ -72,13 +72,13 @@ func Decrypt(content []byte, opts ...Option) ([]byte, error) {
 		start = end
 		counter++
 	}
-	return resultsJoin(results), nil
+	return join(results), nil
 }
 
 func readHeader(opt *options, content []byte) []byte {
 	if opt.encoding == AES128GCM {
-		baseOffset := keyLen + recodeSizeLen
-		idLen := int(content[baseOffset])
+		baseOffset := uint32(keyLen + recodeSizeLen)
+		idLen := uint32(content[baseOffset])
 
 		opt.salt = content[0:keyLen]
 		opt.recordSize = binary.BigEndian.Uint32(content[keyLen:baseOffset])

--- a/encrypt.go
+++ b/encrypt.go
@@ -104,7 +104,7 @@ func Encrypt(plaintext []byte, opts ...Option) ([]byte, error) {
 		start = end
 		counter++
 	}
-	return resultsJoin(results), nil
+	return join(results), nil
 }
 
 func encryptRecord(opt *options, gcm cipher.AEAD, nonce []byte, plaintext []byte, last bool) []byte {
@@ -145,8 +145,7 @@ func writeHeader(opt *options, results [][]byte) ([][]byte, error) {
 		copy(buffer[saltLen:], uint32ToBytes(opt.recordSize))
 		buffer[saltLen+4] = uint8(keyIDLen)
 		copy(buffer[saltLen+5:], opt.keyID)
-		results = append(results, buffer)
-		return results, nil
+		return append(results, buffer), nil
 	default:
 		// No header on other versions
 		return results, nil

--- a/keys.go
+++ b/keys.go
@@ -50,7 +50,6 @@ func deriveKeyAndNonce(opt *options) (key, nonce, error) {
 
 	debug.dumpBinary("info aesgcm", keyInfo)
 	debug.dumpBinary("info nonce", nonceInfo)
-
 	debug.dumpBinary("hkdf secret", secret)
 	debug.dumpBinary("hkdf salt", opt.salt)
 
@@ -60,7 +59,7 @@ func deriveKeyAndNonce(opt *options) (key, nonce, error) {
 	debug.dumpBinary("hkdf info", keyInfo)
 
 	key := make([]byte, keyLen)
-	_, err = hkdf.Expand(hashAlgorithm, prk, keyInfo).Read(key)
+	_, err = io.ReadFull(hkdf.Expand(hashAlgorithm, prk, keyInfo), key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +69,7 @@ func deriveKeyAndNonce(opt *options) (key, nonce, error) {
 	debug.dumpBinary("hkdf info", nonceInfo)
 
 	nonce := make([]byte, nonceLen)
-	if _, err = hkdf.Expand(hashAlgorithm, prk, nonceInfo).Read(nonce); err != nil {
+	if _, err = io.ReadFull(hkdf.Expand(hashAlgorithm, prk, nonceInfo), nonce); err != nil {
 		return nil, nil, err
 	}
 	debug.dumpBinary("base nonce", nonce)
@@ -152,7 +151,7 @@ func extractSecret(opt *options) ([]byte, error) {
 	debug.dumpBinary("hkdf info", authInfo)
 
 	newSecret := make([]byte, secretLen)
-	_, err = hkdf.New(hashAlgorithm, secret, opt.authSecret, authInfo).Read(newSecret)
+	_, err = io.ReadFull(hkdf.New(hashAlgorithm, secret, opt.authSecret, authInfo),newSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/utils.go
+++ b/utils.go
@@ -14,6 +14,8 @@ import (
 	"log"
 )
 
+const maxInt = int(^uint(0) >> 1)
+
 var debug = debugT(false)
 
 type debugT bool
@@ -81,13 +83,19 @@ func xor12(dst []byte, a []byte, b []byte) {
 	dst[11] = a[11] ^ b[11]
 }
 
-func resultsJoin(s [][]byte) []byte {
+func join(s [][]byte) []byte {
+	if len(s) == 0 {
+		return []byte{}
+	}
 	if len(s) == 1 {
-		return s[0]
+		return append([]byte(nil), s[0]...)
 	}
 
-	n := 0
+	var n int
 	for _, v := range s {
+		if len(v) > maxInt-n {
+			panic("join output length overflow")
+		}
 		n += len(v)
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -56,10 +56,10 @@ func TestGenerateNonce(t *testing.T) {
 	assert.Equal(t, expect, generateNonce(tmp, 0xffffffff))
 }
 
-func TestResultsJoin(t *testing.T) {
-	assert.Equal(t, []byte{0x01}, resultsJoin([][]byte{{0x01}}))
-	assert.Equal(t, []byte{0x01, 0x02}, resultsJoin([][]byte{{0x01}, {0x02}}))
-	assert.Equal(t, []byte{0x01, 0x02, 0x03}, resultsJoin([][]byte{{0x01}, {0x02}, {0x03}}))
+func TestJoin(t *testing.T) {
+	assert.Equal(t, []byte{0x01}, join([][]byte{{0x01}}))
+	assert.Equal(t, []byte{0x01, 0x02}, join([][]byte{{0x01}, {0x02}}))
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, join([][]byte{{0x01}, {0x02}, {0x03}}))
 }
 
 func TestRandomSalt(t *testing.T) {


### PR DESCRIPTION
- マイナスにならない変数はuint32に変更
- バイト配列の結合時の戻り値は、入力値と常に異なるオブジェクトになるように変更. 長さチェック追加
- 鍵交換処理の配列への読み込みは、io.ReadFullを常に使用し、部分読み込みとならないようにする